### PR TITLE
ci(coverage): add jest coverage checks, update docs on coverage checks

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -45,14 +45,14 @@ jobs:
           check-latest: true
       - run: yarn
       - run: yarn test:ci
-#      - name: Upload Coverage Report
-#        uses: actions/upload-artifact@v3
-#        with:
-#          path: coverage/lcov-report
-#      - name: 'Upload coverage to Codecov'
-#        uses: codecov/codecov-action@v3
-#        with:
-#          token: ${{ secrets.CODECOV_TOKEN }}
+  #      - name: Upload Coverage Report
+  #        uses: actions/upload-artifact@v3
+  #        with:
+  #          path: coverage/lcov-report
+  #      - name: 'Upload coverage to Codecov'
+  #        uses: codecov/codecov-action@v3
+  #        with:
+  #          token: ${{ secrets.CODECOV_TOKEN }}
   deploy:
     name: Deploy
     if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ For lower level tests of utilities and individual modules, we use [Jest](https:/
 ## Test coverage checks
 
 ### For private repos
+
 For private repos, Jest can be configured to terminate with an error status if there is less coverage than some configurable threshold.
 This project applies coverage thresholds for `yarn test:ci`, so CI checks will fail if there is insufficient test coverage.
 
@@ -51,11 +52,14 @@ Make sure to add fixture data, mocks, or other files and file paths that you don
 to `coveragePathIgnorePatterns` in `jest.config.js`.
 
 ### For public repos
+
 For public repos, [Codecov](https://codecov.io) is free. The tool offers two nice features that Jest doesn't offer out of the box:
+
 - "auto" coverage targets, which track the current coverage of the `main` branch. This lets you guarantee that test coverage increases over time.
 - "patch" coverage, counting only the lines modified by the current PR
 
 Here's how to set it up:
+
 - Get a token for the repo [following these instructions](https://docs.codecov.com/docs#step-2-get-the-repository-upload-token).
 - Add `CODECOV_TOKEN` to the repo secrets [following these instructions](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-codespaces#adding-secrets-for-a-repository).
 - Uncomment the `Upload Coverage Report` and `Upload coverage to Codecov` steps in `workflow.yaml`

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,9 +15,7 @@ module.exports = {
   },
   setupFiles: ['<rootDir>/jest.setup.js'],
   collectCoverageFrom: ['./src/**/*.ts'],
-  coveragePathIgnorePatterns: [
-    '/node_modules/',
-  ],
+  coveragePathIgnorePatterns: ['/node_modules/'],
   coverageThreshold: {
     global: {
       lines: 80,


### PR DESCRIPTION
Configured jest checks by default, and added steps to enable Codecov for public repos to the README, commenting out the workflow steps so they can be easily re-enabled as needed.

I'd also be fine with deleting the codecov steps from the workflow and putting them in the readme as well, though it may be a bit more error prone re-enabling codecov that way.