### PR TITLE
feat: add workflow to enforce semantic PR title

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,0 +1,18 @@
+name: Semantic PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  semantic-pr-title:
+    name: Semantic PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A starter template for Valora TypeScript projects with best practices.
 - Scripts using [ShellJS](https://github.com/shelljs/shelljs)
   - Linted and statically checked with [TypeScript](https://www.typescriptlang.org/)
 - CI/CD with [GitHub Actions](https://docs.github.com/en/actions)
+  - Semantic PR title enforcement with [semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)
 - Automated dependency updates with [Renovate](https://renovatebot.com/), configured with [valora-inc/renovate-config](https://github.com/valora-inc/renovate-config)
 
 ## How to use this?
@@ -82,6 +83,8 @@ To run external commands we recommend using [ShellJS](https://github.com/shelljs
 ## GitHub Actions
 
 We use [GitHub Actions](https://docs.github.com/en/actions) for continuous integration and deployment (CI/CD). Anything that gets into the `main` branch will be deployed using `yarn deploy` after running tests/build/etc.
+
+Also, we use [semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) to ensure PR titles match the [Conventional Commits spec](https://www.conventionalcommits.org/). It can be used in combination with [semantic-release](https://github.com/semantic-release/semantic-release) to automate releases and changelogs.
 
 ## Renovate
 


### PR DESCRIPTION
We decided to use semantic PR title as it can help with automated releases and changelog generation.
This helps ensure new repos will enforce that rule too.

Already used in https://github.com/valora-inc/logging/pull/7

See also: https://valora-app.slack.com/archives/C025V1D6F3J/p1669991436336709