### PR TITLE
fix: eslint json linting

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -1,0 +1,4 @@
+{
+  "some": "data",
+  "important": true
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "src/**/*.json", "scripts", "scripts/**/*.json" ],
+  "include": ["src", "src/**/*.json", "scripts", "scripts/**/*.json"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "scripts"],
+  "include": ["src", "src/**/*.json", "scripts", "scripts/**/*.json" ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
For the @typescript-eslint/parser the tsconfig needs to include all files being linted. We need to explicitly include .json files per the default rule:

  https://www.typescriptlang.org/tsconfig#include

```
If a glob pattern doesn’t include a file extension, then only files with supported extensions are included (e.g. .ts, .tsx, and .d.ts by default, with .js and .jsx if allowJs is set to true).
```