### PR TITLE
fix: ignore credentials from google-github-actions/auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # IDE
 .idea
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
See [context](https://valora-app.slack.com/archives/C025V1D6F3J/p1680259094963239).