### PR TITLE
fix: update prettier log level parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "yarn build && yarn build:scripts",
     "lint": "eslint --ext=.tsx,.ts,.json src/ scripts/",
     "lint:fix": "yarn lint --fix",
-    "format": "prettier --loglevel error --write .",
+    "format": "prettier --log-level error --write .",
     "format:check": "prettier --check .",
     "depcheck": "depcheck",
     "test": "jest",


### PR DESCRIPTION
```
$ prettier --loglevel error --write .
[warn] Ignored unknown option --loglevel=error. Did you mean --log-level?
```

Likely changed with the upgrade to prettier v3