### PR TITLE
ci: add alerting for deploy workflow step failures

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -71,6 +71,17 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: celo-mobile-mainnet
+          credentials_json: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
+      - name: Fetch Secrets
+        id: slack-webhook
+        uses: google-github-actions/get-secretmanager-secrets@v2.0.0
+        with:
+          # This can point to any slack webhook URL stored in GC Secret Manager
+          secrets: |-
+            SLACK_WEBHOOK_URL:projects/1027349420744/secrets/SLACK_ONCALL_WEBHOOK_URL
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -78,3 +89,16 @@ jobs:
           check-latest: true
       - run: yarn
       - run: yarn deploy
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notification_title: '{workflow} has {status_message}'
+          message_format: '{emoji} *{workflow}* {status_message}. <{run_url}|View Run>'
+          footer: 'Repo: <{repo_url}|{repo}>'
+          notify_when: 'failure'
+          # Tag @supporthero on failures, can change to any slack group id
+          mention_groups: 'S0277QUM4KB'
+          mention_groups_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.slack-webhook.outputs.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -71,6 +71,8 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
+      # Repo needs to be given access to the MAINNET_SERVICE_ACCOUNT_KEY secret to access the slack webhook
+      # https://github.com/organizations/valora-inc/settings/secrets/actions/MAINNET_SERVICE_ACCOUNT_KEY
       - uses: google-github-actions/auth@v2
         with:
           project_id: celo-mobile-mainnet

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ We use [GitHub Actions](https://docs.github.com/en/actions) for continuous integ
 
 Also, we use [semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) to ensure PR titles match the [Conventional Commits spec](https://www.conventionalcommits.org/). It can be used in combination with [semantic-release](https://github.com/semantic-release/semantic-release) to automate releases and changelogs.
 
-[`workflow.yaml`](.github/workflows/workflow.yaml) contains a step to send slack notifications on deploy failures. For this to work, your repo needs to have access to the [MAINNET_SERVICE_KEY](https://github.com/organizations/valora-inc/settings/secrets/actions/MAINNET_SERVICE_ACCOUNT_KEY) github secret.
+[`workflow.yaml`](.github/workflows/workflow.yaml) contains a step to send slack notifications on deploy failures. For this to work, your repo needs to have access to the [MAINNET_SERVICE_ACCOUNT_KEY](https://github.com/organizations/valora-inc/settings/secrets/actions/MAINNET_SERVICE_ACCOUNT_KEY) github secret.
 
 ## Renovate
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ We use [GitHub Actions](https://docs.github.com/en/actions) for continuous integ
 
 Also, we use [semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) to ensure PR titles match the [Conventional Commits spec](https://www.conventionalcommits.org/). It can be used in combination with [semantic-release](https://github.com/semantic-release/semantic-release) to automate releases and changelogs.
 
+[`workflow.yaml`](.github/workflows/workflow.yaml) contains a step to send slack notifications on deploy failures. For this to work, your repo needs to have access to the [MAINNET_SERVICE_KEY](https://github.com/organizations/valora-inc/settings/secrets/actions/MAINNET_SERVICE_ACCOUNT_KEY) github secret.
+
 ## Renovate
 
 [Renovate](https://renovatebot.com/) ensures our dependencies are kept up to date. It's configured with our shared config in [`renovate.json5`](renovate.json5).

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Also, we use [semantic-pull-request](https://github.com/amannn/action-semantic-p
 
 [`workflow.yaml`](.github/workflows/workflow.yaml) contains a step to send slack notifications on deploy failures. For this to work, your repo needs to have access to the [MAINNET_SERVICE_ACCOUNT_KEY](https://github.com/organizations/valora-inc/settings/secrets/actions/MAINNET_SERVICE_ACCOUNT_KEY) github secret.
 
+will this make actions work???
+
 ## Renovate
 
 [Renovate](https://renovatebot.com/) ensures our dependencies are kept up to date. It's configured with our shared config in [`renovate.json5`](renovate.json5).

--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ Also, we use [semantic-pull-request](https://github.com/amannn/action-semantic-p
 
 [`workflow.yaml`](.github/workflows/workflow.yaml) contains a step to send slack notifications on deploy failures. For this to work, your repo needs to have access to the [MAINNET_SERVICE_ACCOUNT_KEY](https://github.com/organizations/valora-inc/settings/secrets/actions/MAINNET_SERVICE_ACCOUNT_KEY) github secret.
 
-will this make actions work???
-
 ## Renovate
 
 [Renovate](https://renovatebot.com/) ensures our dependencies are kept up to date. It's configured with our shared config in [`renovate.json5`](renovate.json5).


### PR DESCRIPTION
Alerting was added in to valora-rest-api workflow to alert on deploy failures here: https://github.com/valora-inc/valora-rest-api/pull/817

Adding in this alerting code here so new repos get set up with deploy failure alerting already in place.