### PR TITLE
chore: use node 20

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version-file: 'package.json'
           check-latest: true
       - run: yarn
       - run: yarn typecheck
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version-file: 'package.json'
           check-latest: true
       - run: yarn
       - run: yarn knip
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version-file: 'package.json'
           check-latest: true
       - run: yarn
       - run: yarn test:ci
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version-file: 'package.json'
           check-latest: true
       - run: yarn
       - run: yarn deploy

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "node": "^18"
+    "node": "^20"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
I used the starter and noticed it was still on node 18. So updating now.