### PR TITLE
chore: update deprecated import

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
 
 module.exports = {
   moduleFileExtensions: ['ts', 'js', 'json'],


### PR DESCRIPTION
Noticed the deprecation as I was working on https://github.com/valora-inc/viem-account-hsm-gcp/pull/6